### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/jasonkeicher/7fb4e870-8e21-4129-85cd-bb25e245e2c6/6e2fc191-871b-414c-a40a-232ffb2eca0b/_apis/work/boardbadge/7ec9bbba-e00f-4d2c-b310-1730484870c7)](https://dev.azure.com/jasonkeicher/7fb4e870-8e21-4129-85cd-bb25e245e2c6/_boards/board/t/6e2fc191-871b-414c-a40a-232ffb2eca0b/Microsoft.RequirementCategory)
 [![Build Status](https://dev.azure.com/appdev-gbb/kubernetes-hackfest/_apis/build/status/dstrebel.kubernetes-hackfest)](https://dev.azure.com/appdev-gbb/kubernetes-hackfest/_build/latest?definitionId=2)
 
 ## Prerequisites 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2716](https://dev.azure.com/jasonkeicher/7fb4e870-8e21-4129-85cd-bb25e245e2c6/_workitems/edit/2716). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.